### PR TITLE
Generalize bulk edit title

### DIFF
--- a/campaignion_manage/lib/BulkOpForm.php
+++ b/campaignion_manage/lib/BulkOpForm.php
@@ -14,7 +14,7 @@ class BulkOpForm {
     $form['bulk-wrapper'] = array(
       '#type' => 'fieldset',
       '#attributes' => array('class' => array('bulkops')),
-      '#title' => t('Bulk edit your selected supporters'),
+      '#title' => t('Bulk edit your selection'),
     );
     $form['bulk-wrapper']['info'] = array(
       '#markup' => '<div class="bulkop-selected">' . t('!count items selected.', array('!count' => '<span class="bulkop-count"></span>')) . '</div>',


### PR DESCRIPTION
Since the Bulk Edit form is not only shown for supporter management but content as well, the title should be more general (or specific for every case). This seems to be the easier solution ;)